### PR TITLE
Fix NullTest formatting in WHERE clauses

### DIFF
--- a/formatter/node_formatter/format_nulltest.go
+++ b/formatter/node_formatter/format_nulltest.go
@@ -1,0 +1,44 @@
+package nodeformatter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v5"
+)
+
+func FormatNullTest(ctx context.Context, nt *pg_query.Node_NullTest) (string, error) {
+	var bu strings.Builder
+
+	if nt.NullTest.Arg != nil {
+		switch arg := nt.NullTest.Arg.Node.(type) {
+		case *pg_query.Node_ColumnRef:
+			field, err := FormatColumnRefFields(ctx, arg)
+			if err != nil {
+				return "", err
+			}
+			bu.WriteString(field)
+		case *pg_query.Node_ParamRef:
+			bu.WriteString("$")
+			bu.WriteString(fmt.Sprint(arg.ParamRef.Number))
+		case *pg_query.Node_AConst:
+			res, err := FormatAConst(ctx, arg)
+			if err != nil {
+				return "", err
+			}
+			bu.WriteString(res)
+		}
+	}
+
+	switch nt.NullTest.Nulltesttype {
+	case pg_query.NullTestType_IS_NULL:
+		bu.WriteString(" IS NULL")
+	case pg_query.NullTestType_IS_NOT_NULL:
+		bu.WriteString(" IS NOT NULL")
+	default:
+		return "", fmt.Errorf("FormatNullTest: unknown NullTestType")
+	}
+
+	return bu.String(), nil
+}

--- a/formatter/where_clause_format.go
+++ b/formatter/where_clause_format.go
@@ -58,6 +58,24 @@ func formatBoolExpr(ctx context.Context, be *pg_query.Node_BoolExpr, indent int,
 			bu.WriteString("\n")
 			bu.WriteString(internal.GetIndent(conf))
 			bu.WriteString(")")
+		case *pg_query.Node_NullTest:
+			res, err := nodeformatter.FormatNullTest(ctx, n)
+			if err != nil {
+				return "", err
+			}
+			if argI != 0 {
+				bu.WriteString("\n")
+				for i := 0; i <= indent; i++ {
+					bu.WriteString(internal.GetIndent(conf))
+				}
+				boolStr, err := enumconv.BoolExprTypeToString(be.BoolExpr.Boolop)
+				if err != nil {
+					return "", err
+				}
+				bu.WriteString(boolStr)
+				bu.WriteString(" ")
+			}
+			bu.WriteString(res)
 		case *pg_query.Node_SubLink:
 			if selectStmt, ok := n.SubLink.Subselect.Node.(*pg_query.Node_SelectStmt); ok {
 				res, err := FormatSelectStmt(ctx, selectStmt, indent+1, conf)


### PR DESCRIPTION
## Summary
- implement `FormatNullTest` for handling `IS NULL` expressions
- support `Node_NullTest` in boolean expressions and WHERE clauses

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68500d640130832a9ad2c3c15158ecba